### PR TITLE
Feature/improve logging

### DIFF
--- a/JPEG-Encoder/encoder.console/Encoder.cs
+++ b/JPEG-Encoder/encoder.console/Encoder.cs
@@ -20,8 +20,6 @@ namespace encoder.console
       //char[] input2 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbccccccccddddeefg".ToCharArray();
       char[] input2 = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbccccccccddddeefg".ToCharArray();
 
-
-
       LogLine("Input content:");
       LogLine(new string(input2));
       LogLine();
@@ -33,18 +31,16 @@ namespace encoder.console
       tree.RightBalance();
       tree.Print();
 
-      // // Encode symbols by huffman tree
+      // Encode symbols by huffman tree
       BitStream bitStream = tree.Encode(input2);
 #if DEBUG
       bitStream.PrettyPrint();
-#endif
-
-
       LogLine();
+#endif
 
       bitStream.Reset();
 
-      // // Decode symbols by huffman tree
+      // Decode symbols by huffman tree
       char[] decodedCode = tree.Decode(bitStream);
 
       LogLine("Decoded content:");

--- a/JPEG-Encoder/encoder.console/Encoder.cs
+++ b/JPEG-Encoder/encoder.console/Encoder.cs
@@ -19,9 +19,12 @@ namespace encoder.console
       //char[] input2 = "aabbbcccddddeeeeffffgggghhhhhiiiiijjjjjkkkkklllllmmmmmmnnnnnnoooooopppppppqqqqqqqrrrrrrrssssssssttttttttuuuuuuuuvvvvvvvvwwwwwwwwxxxxxxxxxyyyyyyyyy".ToCharArray();
       //char[] input2 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbccccccccddddeefg".ToCharArray();
       char[] input2 = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbccccccccddddeefg".ToCharArray();
-      Console.WriteLine("Input content:");
-      Console.WriteLine(new string(input2));
-      Console.WriteLine();
+
+
+
+      LogLine("Input content:");
+      LogLine(new string(input2));
+      LogLine();
 
       // Build huffman tree
       HuffmanTree tree = new HuffmanTree();
@@ -34,15 +37,15 @@ namespace encoder.console
       BitStream bitStream = tree.Encode(input2);
       bitStream.PrettyPrint();
 
-      Console.WriteLine();
+      LogLine();
 
       bitStream.Reset();
 
       // // Decode symbols by huffman tree
       char[] decodedCode = tree.Decode(bitStream);
 
-      Console.WriteLine("Decoded content:");
-      Console.WriteLine(new string(decodedCode));
+      LogLine("Decoded content:");
+      LogLine(new string(decodedCode));
     }
 
     public static void writeJPEGHeader(string ppmFileName, string jpegFileName)
@@ -92,6 +95,21 @@ namespace encoder.console
         bitStream.writeToStream(outputFileStream);
       }
     }
+
+    private static void LogLine(string message = null)
+    {
+#if DEBUG
+      Console.WriteLine(message);
+#endif
+    }
+
+    private static void Log(string message = null)
+    {
+#if DEBUG
+      Console.Write(message);
+#endif
+    }
+
   }
 }
 

--- a/JPEG-Encoder/encoder.console/Encoder.cs
+++ b/JPEG-Encoder/encoder.console/Encoder.cs
@@ -31,12 +31,13 @@ namespace encoder.console
       tree.RightBalance();
       tree.Print();
 
+
       // Encode symbols by huffman tree
       BitStream bitStream = tree.Encode(input2);
-#if DEBUG
-      bitStream.PrettyPrint();
-      LogLine();
-#endif
+      // #if DEBUG
+      //       bitStream.PrettyPrint();
+      //       LogLine();
+      // #endif
 
       bitStream.Reset();
 

--- a/JPEG-Encoder/encoder.console/Encoder.cs
+++ b/JPEG-Encoder/encoder.console/Encoder.cs
@@ -35,7 +35,10 @@ namespace encoder.console
 
       // // Encode symbols by huffman tree
       BitStream bitStream = tree.Encode(input2);
+#if DEBUG
       bitStream.PrettyPrint();
+#endif
+
 
       LogLine();
 

--- a/JPEG-Encoder/encoder.console/lib/HuffmanTree.cs
+++ b/JPEG-Encoder/encoder.console/lib/HuffmanTree.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -8,7 +8,7 @@ namespace encoder.lib
   public class HuffmanTree
   {
     private const int MAX_DEPTH = 3;
-    private const char DEFAULT_NODE_SYMBOL = ' ';
+    private const char DEFAULT_NODE_SYMBOL = 'x';
 
     public Dictionary<char, int> frequencies = new Dictionary<char, int>();
     public Node Root { get; set; }
@@ -29,29 +29,30 @@ namespace encoder.lib
 
     private void Print(Node currentNode)
     {
-      if (currentNode.Left != null && currentNode.Right == null)
+      Log("(");
+
+      if (currentNode.Right == null && currentNode.Left == null)
       {
-        Log("(");
-        Log(currentNode.Left.Symbol);
+        Log("#\\");
         Log(currentNode.Symbol);
-        Log("");
         Log(")");
         return;
-
       }
+
+      Log("#\\");
+      Log(currentNode.Depth);
+
       if (currentNode.Left != null)
       {
-        Log("(");
         Print(currentNode.Left);
       }
-
-      Log(currentNode.Symbol);
 
       if (currentNode.Right != null)
       {
         Print(currentNode.Right);
-        Log(")");
       }
+
+      Log(")");
     }
 
     //encode einen beliebigen char Array zu Bitstream

--- a/JPEG-Encoder/encoder.console/lib/HuffmanTree.cs
+++ b/JPEG-Encoder/encoder.console/lib/HuffmanTree.cs
@@ -7,7 +7,7 @@ namespace encoder.lib
 {
   public class HuffmanTree
   {
-    private const int MAX_DEPTH = 1;
+    private const int MAX_DEPTH = 3;
 
     public Dictionary<char, int> frequencies = new Dictionary<char, int>();
     public Node Root { get; set; }
@@ -319,8 +319,8 @@ namespace encoder.lib
                                      .ThenByDescending(node => node.Frequence)
                                      .ToList();
 
-      // depth constrains
-      DepthConstrain();
+      // constrain depth of tree (only if it's constrainable)
+      if (nodesWithDepth.Last().Depth > MAX_DEPTH) DepthConstrain();
 
       // TODO: sort by Freuquency
       nodesWithDepth = nodesWithDepth.OrderBy(node => node.Depth)

--- a/JPEG-Encoder/encoder.console/lib/HuffmanTree.cs
+++ b/JPEG-Encoder/encoder.console/lib/HuffmanTree.cs
@@ -8,6 +8,7 @@ namespace encoder.lib
   public class HuffmanTree
   {
     private const int MAX_DEPTH = 3;
+    private const char DEFAULT_NODE_SYMBOL = ' ';
 
     public Dictionary<char, int> frequencies = new Dictionary<char, int>();
     public Node Root { get; set; }
@@ -200,7 +201,7 @@ namespace encoder.lib
           // create the parent node of the combinded elements
           Node parent = new Node()
           {
-            Symbol = '^',
+            Symbol = DEFAULT_NODE_SYMBOL,
             Frequence = sortedNodes[0].Frequence + sortedNodes[1].Frequence,
             Left = sortedNodes[0],
             Right = sortedNodes[1]
@@ -328,7 +329,7 @@ namespace encoder.lib
                                      .ToList();
 
       // create new root and add leaves
-      Node newRoot = new Node() { Symbol = '^', Depth = 0 };
+      Node newRoot = new Node() { Symbol = DEFAULT_NODE_SYMBOL, Depth = 0 };
       var currentDepth = 1;
       addLeaves(newRoot, currentDepth);
 
@@ -353,7 +354,7 @@ namespace encoder.lib
       else
       {
         // create interims node and add leaves recursively
-        Node nextNode = new Node() { Symbol = '^', Depth = currentDepth };
+        Node nextNode = new Node() { Symbol = DEFAULT_NODE_SYMBOL, Depth = currentDepth };
         currentNode.Left = nextNode;
         addLeaves(nextNode, currentDepth + 1);
       }
@@ -364,7 +365,7 @@ namespace encoder.lib
         if (nodesWithDepth.Count == 1)
         {
           // last added node is moved one deeper and to the left
-          Node nextNode = new Node() { Symbol = '^', Depth = currentDepth };
+          Node nextNode = new Node() { Symbol = DEFAULT_NODE_SYMBOL, Depth = currentDepth };
           currentNode.Right = nextNode;
           nextNode.Left = nodesWithDepth[0];
           nodesWithDepth.RemoveAt(0);
@@ -380,7 +381,7 @@ namespace encoder.lib
       else
       {
         // create interims node and add leaves recursively
-        Node nextNode = new Node() { Symbol = '^', Depth = currentDepth };
+        Node nextNode = new Node() { Symbol = DEFAULT_NODE_SYMBOL, Depth = currentDepth };
         currentNode.Right = nextNode;
         addLeaves(nextNode, currentDepth + 1);
       }
@@ -414,6 +415,13 @@ namespace encoder.lib
     }
 
     private static void Log(int message = 0)
+    {
+#if DEBUG
+      Console.Write(message);
+#endif
+    }
+
+    private static void Log(char message = ' ')
     {
 #if DEBUG
       Console.Write(message);

--- a/JPEG-Encoder/encoder.console/lib/HuffmanTree.cs
+++ b/JPEG-Encoder/encoder.console/lib/HuffmanTree.cs
@@ -17,39 +17,39 @@ namespace encoder.lib
 
     public void Print()
     {
-      Console.WriteLine("Huffman-Tree:");
+      LogLine("Huffman-Tree:");
 
-      if (Root == null) Console.WriteLine("Baum ist leer");
+      if (Root == null) LogLine("Baum ist leer");
       else Print(Root);
 
-      Console.WriteLine();
-      Console.WriteLine();
+      LogLine();
+      LogLine();
     }
 
     private void Print(Node currentNode)
     {
       if (currentNode.Left != null && currentNode.Right == null)
       {
-        Console.Write("(");
-        Console.Write(currentNode.Left.Symbol);
-        Console.Write(currentNode.Symbol);
-        Console.Write("");
-        Console.Write(")");
+        Log("(");
+        Log(currentNode.Left.Symbol);
+        Log(currentNode.Symbol);
+        Log("");
+        Log(")");
         return;
 
       }
       if (currentNode.Left != null)
       {
-        Console.Write("(");
+        Log("(");
         Print(currentNode.Left);
       }
 
-      Console.Write(currentNode.Symbol);
+      Log(currentNode.Symbol);
 
       if (currentNode.Right != null)
       {
         Print(currentNode.Right);
-        Console.Write(")");
+        Log(")");
       }
     }
 
@@ -64,15 +64,15 @@ namespace encoder.lib
       // Print dictionary
       foreach (KeyValuePair<char, int> element in frequencies)
       {
-        Console.Write(element.Key + ": ");
+        Log(element.Key + ": ");
         BitArray bits = dictionary[element.Key];
         foreach (bool bit in bits)
         {
-          Console.Write((bit ? 1 : 0));
+          Log((bit ? 1 : 0));
         }
-        Console.WriteLine();
+        LogLine();
       }
-      Console.WriteLine();
+      LogLine();
 
       // write to Bitstream
       foreach (char token in input)
@@ -125,11 +125,11 @@ namespace encoder.lib
       List<bool> bits = new List<bool>();
       Dictionary<char, BitArray> dictionary = new Dictionary<char, BitArray>();
 
-      Console.WriteLine("Dictionary:");
+      LogLine("Dictionary:");
 
       if (Root == null)
       {
-        Console.WriteLine("<empty>");
+        LogLine("<empty>");
       }
       else
       {
@@ -229,7 +229,7 @@ namespace encoder.lib
         int difference = node.Depth - MAX_DEPTH;
         totalCost += calculateCost(difference);
       }
-      Console.WriteLine("--> " + totalCost);
+      LogLine("--> " + totalCost);
 
       // set all nodes that are too deep to Max_DEPTH
       nodesWithDepth.ForEach(node => { if (node.Depth > MAX_DEPTH) node.Depth = MAX_DEPTH; });
@@ -300,7 +300,7 @@ namespace encoder.lib
         sum += Math.Pow(0.5, i);
       }
 
-      Console.WriteLine("Calculated Costs: " + sum);
+      LogLine("Calculated Costs: " + sum);
 
       // when adding up costs it should always return whole number
       return sum;
@@ -397,6 +397,30 @@ namespace encoder.lib
       calculateNodeDepths(currentNode.Left, currentDepth + 1);
       calculateNodeDepths(currentNode.Right, currentDepth + 1);
     }
+
+    #region logger
+    private static void LogLine(string message = null)
+    {
+#if DEBUG
+      Console.WriteLine(message);
+#endif
+    }
+
+    private static void Log(string message = null)
+    {
+#if DEBUG
+      Console.Write(message);
+#endif
+    }
+
+    private static void Log(int message = 0)
+    {
+#if DEBUG
+      Console.Write(message);
+#endif
+    }
+    #endregion
+
   }
 
 

--- a/JPEG-Encoder/encoder.console/utils/TreeVisualisation.rkt
+++ b/JPEG-Encoder/encoder.console/utils/TreeVisualisation.rkt
@@ -1,0 +1,13 @@
+#lang racket/base
+ 
+(define (visualize t0)
+  (let loop ([t t0] [last? #t] [indent '()])
+    (define (I mid last) (cond [(eq? t t0) ""] [last? mid] [else last]))
+    (for-each display (reverse indent))
+    (unless (eq? t t0) (printf "│\n"))
+    (for-each display (reverse indent))
+    (printf "~a~a\n" (I "└─" "├─") (car t))
+    (for ([s (cdr t)] [n (in-range (- (length t) 2) -1 -1)])
+      (loop s (zero? n) (cons (I "  " "│ ") indent)))))
+ 
+(visualize '(#\x(#\x(#\x(#\x)(#\a))(#\x(#\b)(#\c)))(#\x(#\x(#\d)(#\e))(#\x(#\f)(#\x(#\g))))))


### PR DESCRIPTION
Logging now depends on the build type, so passing `--configuration DEBUG` (also the default) will show all console print outs, while passing `--configuration BUILD` will not. Furthermore added a `racket` script that does a tree visualization as seen in the picture below.

<img width="602" alt="image" src="https://user-images.githubusercontent.com/18517541/69181786-05a05f80-0b10-11ea-8631-fb92f72f6b83.png">
